### PR TITLE
Enhance CatalogService with ValueQuickPickItem support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ibm-catalog-json-editor",
   "displayName": "IBM Catalog JSON Editor",
   "description": "VS Code extension for managing IBM Cloud catalog JSON files",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "publisher": "DanielButler",
   "repository": {
     "type": "git",

--- a/src/types/quickPick.ts
+++ b/src/types/quickPick.ts
@@ -1,0 +1,5 @@
+import * as vscode from 'vscode';
+
+export interface ValueQuickPickItem<T = string> extends vscode.QuickPickItem {
+    value: T;
+}


### PR DESCRIPTION
Introduce `ValueQuickPickItem` to improve mapping selection in `CatalogService`, allowing for more efficient handling of user selections. This change enhances the user experience by providing clearer value management in quick pick items.
Fixes: https://github.com/daniel-butler-irl/VS_Code_Catalog_Json_Editor/issues/26