### PR TITLE
Refactor prompt service and enhance input mapping prompts

### DIFF
--- a/src/services/CatalogService.ts
+++ b/src/services/CatalogService.ts
@@ -1,3 +1,4 @@
+// src/services/CatalogService.ts
 import * as vscode from 'vscode';
 import { CatalogTreeItem } from '../models/CatalogTreeItem';
 import { AddElementDialog } from '../ui/AddElementDialog';
@@ -7,10 +8,17 @@ import { AuthService } from './AuthService';
 import { LoggingService } from './core/LoggingService';
 import { FileSystemService } from './core/FileSystemService';
 import { InputMappingService } from './InputMappingService';
+import { PromptService } from './core/PromptService';
 import type { Configuration, OfferingFlavor } from '../types/ibmCloud';
 import type { ICatalogFileInfo, MappingOption } from '../types/catalog';
 import { ValueQuickPickItem } from '../types/common';
+import { QuickPickItemEx } from '../types/prompt';
 
+/**
+ * Service responsible for managing catalog data within the extension.
+ * Provides methods to interact with the catalog file, prompt for user input,
+ * and update catalog elements.
+ */
 export class CatalogService {
     private _onDidChangeContent = new vscode.EventEmitter<void>();
     public readonly onDidChangeContent = this._onDidChangeContent.event;
@@ -26,28 +34,52 @@ export class CatalogService {
         });
     }
 
+    /**
+     * Retrieves the file system path of the current catalog file.
+     * @returns The file path as a string, or undefined if not initialized.
+     */
     public getCatalogFilePath(): string | undefined {
         const currentFile = this.fileSystemService.getCurrentCatalogFile();
         return currentFile?.uri.fsPath;
     }
 
+    /**
+     * Retrieves the catalog data from the file system.
+     * @returns A promise that resolves with the catalog data.
+     */
     public async getCatalogData(): Promise<unknown> {
         await this.ensureInitialized();
         return this.fileSystemService.getCatalogData();
     }
 
+    /**
+     * Retrieves the display path of the catalog file.
+     * @returns The display path as a string.
+     */
     public getCatalogDisplayPath(): string {
         return this.fileSystemService.getCatalogDisplayPath();
     }
 
+    /**
+     * Retrieves the current catalog file information.
+     * @returns An object containing catalog file information, or undefined if not initialized.
+     */
     public getCurrentCatalogFile(): ICatalogFileInfo | undefined {
         return this.fileSystemService.getCurrentCatalogFile();
     }
 
+    /**
+     * Checks if the catalog service has been initialized.
+     * @returns True if initialized, false otherwise.
+     */
     public isInitialized(): boolean {
         return this.fileSystemService.isInitialized();
     }
 
+    /**
+     * Initializes the catalog service by loading the catalog file.
+     * @returns A promise that resolves to true if initialized successfully.
+     */
     public async initialize(): Promise<boolean> {
         this.logger.debug('Initializing CatalogService');
         try {
@@ -64,6 +96,10 @@ export class CatalogService {
         }
     }
 
+    /**
+     * Ensures that the catalog service is initialized.
+     * @throws An error if initialization fails.
+     */
     private async ensureInitialized(): Promise<void> {
         if (!this.fileSystemService.isInitialized()) {
             const success = await this.initialize();
@@ -73,10 +109,21 @@ export class CatalogService {
         }
     }
 
+    /**
+     * Updates a value in the catalog JSON data at the specified JSON path.
+     * @param jsonPath The JSON path where the value should be updated.
+     * @param newValue The new value to set.
+     */
     public async updateJsonValue(jsonPath: string, newValue: unknown): Promise<void> {
         await this.ensureInitialized();
         await this.fileSystemService.updateJsonValue(jsonPath, newValue);
     }
+
+    /**
+     * Adds a new element to the catalog at the specified parent node.
+     * @param parentNode The parent node where the element should be added.
+     * @param schemaService The schema service for validation.
+     */
     public async addElement(parentNode: CatalogTreeItem, schemaService: SchemaService): Promise<void> {
         await this.ensureInitialized();
 
@@ -137,6 +184,10 @@ export class CatalogService {
         }
     }
 
+    /**
+     * Edits an existing element in the catalog.
+     * @param node The catalog tree item representing the element to edit.
+     */
     public async editElement(node: CatalogTreeItem): Promise<void> {
         await this.ensureInitialized();
 
@@ -154,9 +205,8 @@ export class CatalogService {
         }
     }
 
-
     /**
-     * Reloads the catalog data from disk
+     * Reloads the catalog data from disk.
      */
     public async reloadCatalogData(): Promise<void> {
         this.logger.debug('Reloading catalog data');
@@ -171,6 +221,10 @@ export class CatalogService {
         }
     }
 
+    /**
+     * Handles the addition of a new input mapping.
+     * @param parentNode The parent node representing the input mapping array.
+     */
     private async handleInputMappingAddition(parentNode: CatalogTreeItem): Promise<void> {
         const mappingType = await this.promptForMappingType();
         if (!mappingType) {
@@ -186,6 +240,10 @@ export class CatalogService {
         await this.updateJsonValue(parentNode.jsonPath, [...currentArray, newMapping]);
     }
 
+    /**
+     * Prompts the user to select a mapping type for input mapping addition.
+     * @returns The selected mapping type, or undefined if cancelled.
+     */
     private async promptForMappingType(): Promise<string | undefined> {
         this.logger.debug('Prompting for mapping type');
         const items: ValueQuickPickItem[] = [
@@ -203,14 +261,27 @@ export class CatalogService {
             }
         ];
 
-        const selection = await vscode.window.showQuickPick(items, {
+        const result = await PromptService.showQuickPick<string>({
             title: 'Select Input Mapping Type',
-            placeHolder: 'Choose the type of mapping to add',
-            canPickMany: false
+            placeholder: 'Choose the type of mapping to add',
+            items: items.map(item => ({
+                label: item.label,
+                description: item.description,
+                detail: item.detail,
+                value: item.value
+            }))
         });
 
-        return selection?.value;
+        return result;
     }
+
+    /**
+     * Prompts the user for a new value for a given node.
+     * Handles different types of nodes and delegates to specific prompt methods.
+     * @param node The catalog tree item to update.
+     * @param currentValue The current value of the node.
+     * @returns The new value, or undefined if cancelled.
+     */
     private async promptForValue(node: CatalogTreeItem, currentValue?: unknown): Promise<unknown> {
         this.logger.debug('Prompting for value', {
             node: node.jsonPath,
@@ -239,10 +310,10 @@ export class CatalogService {
             return this.promptForInputMapping(node, currentValue as string);
         }
 
-        const value = await vscode.window.showInputBox({
-            prompt: `Enter value for ${node.label}`,
-            value: currentValue?.toString() ?? '',
-            validateInput: (value) => {
+        const value = await PromptService.showInputBox<string>({
+            title: `Enter value for ${node.label}`,
+            initialValue: currentValue?.toString() ?? '',
+            validate: (value) => {
                 if (!value.trim()) {
                     return 'Value cannot be empty';
                 }
@@ -261,37 +332,32 @@ export class CatalogService {
         return value;
     }
 
+    /**
+     * Prompts the user to select a boolean value.
+     * @param fieldLabel The label of the field being edited.
+     * @param currentValue The current boolean value.
+     * @returns The selected boolean value, or undefined if cancelled.
+     */
     private async promptForBoolean(fieldLabel: string, currentValue?: boolean): Promise<boolean | undefined> {
         this.logger.debug('Showing boolean pick', {
             fieldLabel,
             currentValue
         });
-        const items: vscode.QuickPickItem[] = [
-            {
-                label: `${currentValue === true ? '$(check) ' : ''}true`,
-                description: 'Set value to true',
-                picked: currentValue === true
-            },
-            {
-                label: `${currentValue === false ? '$(check) ' : ''}false`,
-                description: 'Set value to false',
-                picked: currentValue === false
-            }
-        ];
 
-        const selection = await vscode.window.showQuickPick(items, {
+        return PromptService.showBooleanPick({
             title: `Set value for ${fieldLabel}`,
-            placeHolder: 'Select true or false',
-            canPickMany: false
+            placeholder: 'Select true or false',
+            currentValue,
+            trueLabel: 'true',
+            falseLabel: 'false'
         });
-
-        if (!selection) {
-            return undefined;
-        }
-
-        return selection.label.includes('true');
     }
 
+    /**
+     * Prompts the user to select a catalog ID, fetching available catalogs if possible.
+     * @param currentValue The current catalog ID.
+     * @returns The selected or entered catalog ID, or undefined if cancelled.
+     */
     private async promptForCatalogId(currentValue?: string): Promise<string | undefined> {
         this.logger.debug('Prompting for catalog ID', {
             currentValue
@@ -310,52 +376,42 @@ export class CatalogService {
             const publicCatalogs = catalogs.filter(catalog => catalog.isPublic);
             const privateCatalogs = catalogs.filter(catalog => !catalog.isPublic);
 
-            const items: vscode.QuickPickItem[] = [
-                {
-                    label: "$(edit) Enter Custom Catalog ID",
-                    description: "Manually enter a catalog ID",
-                    alwaysShow: true
-                },
-                {
-                    label: "Available Catalogs",
-                    kind: vscode.QuickPickItemKind.Separator
-                },
+            const items: QuickPickItemEx<string>[] = [
                 {
                     label: "Public Catalogs",
                     kind: vscode.QuickPickItemKind.Separator
-                },
+                } as QuickPickItemEx<string>,
                 ...publicCatalogs.map(catalog => ({
                     label: `${catalog.id === currentValue ? '$(check) ' : ''}${catalog.label}`,
                     description: catalog.id,
-                    detail: catalog.shortDescription
+                    detail: catalog.shortDescription,
+                    value: catalog.id
                 })),
                 {
                     label: "Private Catalogs",
                     kind: vscode.QuickPickItemKind.Separator
-                },
+                } as QuickPickItemEx<string>,
                 ...privateCatalogs.map(catalog => ({
                     label: `${catalog.id === currentValue ? '$(check) ' : ''}${catalog.label}`,
                     description: catalog.id,
-                    detail: catalog.shortDescription
+                    detail: catalog.shortDescription,
+                    value: catalog.id
                 }))
             ];
 
-            const selection = await vscode.window.showQuickPick(items, {
+            const result = await PromptService.showQuickPickWithCustom<string>({
                 title: 'Select Catalog',
-                placeHolder: currentValue || 'Select a catalog or enter a custom ID',
+                placeholder: currentValue || 'Select a catalog or enter a custom ID',
+                items: items,
                 matchOnDescription: true,
-                matchOnDetail: true
+                matchOnDetail: true,
+                customOptionLabel: '$(edit) Enter Custom Catalog ID',
+                customOptionHandler: async () => {
+                    return await this.promptForManualCatalogId(currentValue);
+                }
             });
 
-            if (!selection) {
-                return undefined;
-            }
-
-            if (selection.label === "$(edit) Enter Custom Catalog ID") {
-                return this.promptForManualCatalogId(currentValue);
-            }
-
-            return selection.description;
+            return result;
 
         } catch (error) {
             this.logger.error('Failed to fetch catalogs', error);
@@ -363,11 +419,16 @@ export class CatalogService {
         }
     }
 
+    /**
+     * Prompts the user to manually enter a catalog ID.
+     * @param currentValue The current catalog ID.
+     * @returns The entered catalog ID, or undefined if cancelled.
+     */
     private async promptForManualCatalogId(currentValue?: string): Promise<string | undefined> {
-        return vscode.window.showInputBox({
-            prompt: 'Enter the catalog ID',
-            value: currentValue,
-            validateInput: (value) => {
+        return PromptService.showInputBox<string>({
+            title: 'Enter the catalog ID',
+            initialValue: currentValue,
+            validate: (value) => {
                 if (!value.trim()) {
                     return 'Catalog ID cannot be empty';
                 }
@@ -375,6 +436,13 @@ export class CatalogService {
             }
         });
     }
+
+    /**
+     * Prompts the user to select an offering ID, fetching available offerings if possible.
+     * @param node The catalog tree item associated with the offering.
+     * @param currentValue The current offering ID.
+     * @returns The selected or entered offering ID, or undefined if cancelled.
+     */
     private async promptForOfferingId(node: CatalogTreeItem, currentValue?: string): Promise<string | undefined> {
         this.logger.debug('Prompting for offering ID', {
             currentValue
@@ -396,47 +464,40 @@ export class CatalogService {
             const ibmCloudService = new IBMCloudService(apiKey);
             const offerings = await ibmCloudService.getOfferingsForCatalog(catalogId);
 
-            const items: vscode.QuickPickItem[] = [
-                {
-                    label: "$(edit) Enter Custom Offering ID",
-                    description: "Manually enter an offering ID",
-                    alwaysShow: true
-                },
+            const items: QuickPickItemEx<string>[] = [
                 {
                     label: "Available Offerings",
                     kind: vscode.QuickPickItemKind.Separator
-                },
+                } as QuickPickItemEx<string>,
                 ...offerings.map(offering => ({
                     label: `${offering.id === currentValue ? '$(check) ' : ''}${offering.name}`,
                     description: offering.id,
-                    detail: offering.shortDescription
+                    detail: offering.shortDescription,
+                    value: offering.id
                 }))
             ];
 
-            const selection = await vscode.window.showQuickPick(items, {
+            const result = await PromptService.showQuickPickWithCustom<string>({
                 title: 'Select Offering',
-                placeHolder: currentValue || 'Select an offering or enter a custom ID',
+                placeholder: currentValue || 'Select an offering or enter a custom ID',
+                items: items,
                 matchOnDescription: true,
-                matchOnDetail: true
+                matchOnDetail: true,
+                customOptionLabel: '$(edit) Enter Custom Offering ID',
+                customOptionHandler: async () => {
+                    const customId = await this.promptForManualOfferingId(currentValue);
+                    if (customId) {
+                        await this.updateDependencyName(node, customId);
+                    }
+                    return customId;
+                }
             });
 
-            if (!selection) {
-                return undefined;
+            if (result && result !== currentValue) {
+                await this.updateDependencyName(node, result);
             }
 
-            if (selection.label === "$(edit) Enter Custom Offering ID") {
-                const customId = await this.promptForManualOfferingId(currentValue);
-                if (customId) {
-                    await this.updateDependencyName(node, customId);
-                }
-                return customId;
-            }
-
-            if (selection.description) {
-                await this.updateDependencyName(node, selection.description, selection.label);
-            }
-
-            return selection.description;
+            return result;
 
         } catch (error) {
             this.logger.error('Failed to fetch offerings', error);
@@ -448,11 +509,16 @@ export class CatalogService {
         }
     }
 
+    /**
+     * Prompts the user to manually enter an offering ID.
+     * @param currentValue The current offering ID.
+     * @returns The entered offering ID, or undefined if cancelled.
+     */
     private async promptForManualOfferingId(currentValue?: string): Promise<string | undefined> {
-        return vscode.window.showInputBox({
-            prompt: 'Enter the offering ID',
-            value: currentValue,
-            validateInput: (value) => {
+        return PromptService.showInputBox<string>({
+            title: 'Enter the offering ID',
+            initialValue: currentValue,
+            validate: (value) => {
                 if (!value.trim()) {
                     return 'Offering ID cannot be empty';
                 }
@@ -461,6 +527,12 @@ export class CatalogService {
         });
     }
 
+    /**
+     * Prompts the user to select a flavor, fetching available flavors if possible.
+     * @param node The catalog tree item associated with the flavor.
+     * @param currentValue The current flavor name.
+     * @returns The selected or entered flavor name, or undefined if cancelled.
+     */
     private async promptForFlavor(node: CatalogTreeItem, currentValue?: string): Promise<string | undefined> {
         const logger = this.logger;
         logger.debug('Prompting for flavor', {
@@ -512,17 +584,7 @@ export class CatalogService {
                 return this.promptForManualFlavorInput(currentValue);
             }
 
-            const items: vscode.QuickPickItem[] = [
-                {
-                    label: "$(edit) Enter Custom Flavor",
-                    description: "Manually enter a flavor name",
-                    alwaysShow: true
-                },
-                {
-                    label: "Available Flavors",
-                    kind: vscode.QuickPickItemKind.Separator
-                }
-            ];
+            const items: QuickPickItemEx<string>[] = [];
 
             // Add available flavors with details
             for (const flavorName of flavors) {
@@ -536,7 +598,8 @@ export class CatalogService {
                     items.push({
                         label: `${flavorName === currentValue ? '$(check) ' : ''}${details?.label || flavorName}`,
                         description: flavorName,
-                        detail: this.createFlavorDetail(flavorName, details, currentValue)
+                        detail: this.createFlavorDetail(flavorName, details, currentValue),
+                        value: flavorName
                     });
                 } catch (error) {
                     logger.error('Failed to get flavor details', {
@@ -548,37 +611,40 @@ export class CatalogService {
                     items.push({
                         label: `${flavorName === currentValue ? '$(check) ' : ''}${flavorName}`,
                         description: flavorName,
+                        value: flavorName
                     });
                 }
             }
 
-            const selection = await vscode.window.showQuickPick(items, {
+            const result = await PromptService.showQuickPickWithCustom<string>({
                 title: 'Select Flavor',
-                placeHolder: currentValue || 'Select a flavor or enter a custom name',
+                placeholder: currentValue || 'Select a flavor or enter a custom name',
+                items: items,
                 matchOnDescription: true,
-                matchOnDetail: true
+                matchOnDetail: true,
+                customOptionLabel: '$(edit) Enter Custom Flavor',
+                customOptionHandler: async () => {
+                    return this.promptForManualFlavorInput(currentValue);
+                }
             });
 
-            if (!selection) {
-                return undefined;
-            }
-
-            if (selection.label === "$(edit) Enter Custom Flavor") {
-                return this.promptForManualFlavorInput(currentValue);
-            }
-
-            return selection.description;
+            return result;
         } catch (error) {
             logger.error('Failed to fetch flavors', error);
             return this.promptForManualFlavorInput(currentValue);
         }
     }
 
+    /**
+     * Prompts the user to manually enter a flavor name.
+     * @param currentValue The current flavor name.
+     * @returns The entered flavor name, or undefined if cancelled.
+     */
     private async promptForManualFlavorInput(currentValue?: string): Promise<string | undefined> {
-        const result = await vscode.window.showInputBox({
-            prompt: 'Enter the flavor name',
-            value: currentValue,
-            validateInput: (value) => {
+        const result = await PromptService.showInputBox<string>({
+            title: 'Enter the flavor name',
+            initialValue: currentValue,
+            validate: (value) => {
                 if (!value.trim()) {
                     return 'Flavor name cannot be empty';
                 }
@@ -594,6 +660,13 @@ export class CatalogService {
 
         return result;
     }
+
+    /**
+     * Prompts the user to select an input mapping value.
+     * @param node The catalog tree item associated with the input mapping.
+     * @param currentValue The current mapping value.
+     * @returns The selected mapping value, or undefined if cancelled.
+     */
     private async promptForInputMapping(node: CatalogTreeItem, currentValue?: string): Promise<string | undefined> {
         await this.ensureInitialized();
 
@@ -641,13 +714,13 @@ export class CatalogService {
             }
 
             const configGroups = this.groupConfigurationItems(configurations, node);
-            const items: ValueQuickPickItem[] = [];
+            const items: QuickPickItemEx<string>[] = [];
 
             if (configGroups.required.length > 0) {
                 items.push({
                     label: "Required",
                     kind: vscode.QuickPickItemKind.Separator
-                } as ValueQuickPickItem);
+                } as QuickPickItemEx<string>);
                 items.push(...this.createConfigKeyItems(configGroups.required, currentValue));
             }
 
@@ -655,16 +728,19 @@ export class CatalogService {
                 items.push({
                     label: "Optional",
                     kind: vscode.QuickPickItemKind.Separator
-                } as ValueQuickPickItem);
+                } as QuickPickItemEx<string>);
                 items.push(...this.createConfigKeyItems(configGroups.optional, currentValue));
             }
 
-            const selection = await vscode.window.showQuickPick(items, {
-                placeHolder: currentValue || 'Select version input',
-                title: 'Version Input Keys'
+            const result = await PromptService.showQuickPick<string>({
+                placeholder: currentValue || 'Select version input',
+                title: 'Version Input Keys',
+                items: items,
+                matchOnDescription: true,
+                matchOnDetail: true
             });
 
-            return selection?.value;
+            return result;
         }
 
         if (fieldType === 'dependency_input' || fieldType === 'dependency_output') {
@@ -684,13 +760,13 @@ export class CatalogService {
             }
 
             const groups = this.groupMappingOptions(filteredOptions);
-            const items: ValueQuickPickItem[] = [];
+            const items: QuickPickItemEx<string>[] = [];
 
             if (groups.required.length > 0) {
                 items.push({
                     label: "Required",
                     kind: vscode.QuickPickItemKind.Separator
-                } as ValueQuickPickItem);
+                } as QuickPickItemEx<string>);
                 items.push(...this.createMappingQuickPickItems(groups.required, currentValue));
             }
 
@@ -698,21 +774,29 @@ export class CatalogService {
                 items.push({
                     label: "Optional",
                     kind: vscode.QuickPickItemKind.Separator
-                } as ValueQuickPickItem);
+                } as QuickPickItemEx<string>);
                 items.push(...this.createMappingQuickPickItems(groups.optional, currentValue));
             }
 
-            const selection = await vscode.window.showQuickPick(items, {
-                placeHolder: currentValue || `Select ${fieldType.replace('_', ' ')}`,
-                title: fieldType.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')
+            const result = await PromptService.showQuickPick<string>({
+                placeholder: currentValue || `Select ${fieldType.replace('_', ' ')}`,
+                title: fieldType.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' '),
+                items: items,
+                matchOnDescription: true,
+                matchOnDetail: true
             });
 
-            return selection?.value;
+            return result;
         }
 
         return undefined;
     }
 
+    /**
+     * Retrieves local configuration items from the catalog data.
+     * @param node The catalog tree item to search from.
+     * @returns An array of configurations.
+     */
     private async getLocalConfigurationItems(node: CatalogTreeItem): Promise<Configuration[]> {
         const flavorNode = node.findAncestorFlavorNode();
         if (!flavorNode) {
@@ -729,16 +813,26 @@ export class CatalogService {
         return configuration;
     }
 
-    private createConfigKeyItems(configurations: Configuration[], currentValue?: string): ValueQuickPickItem[] {
+    /**
+     * Creates quick pick items for configuration keys.
+     * @param configurations The configurations to create items for.
+     * @param currentValue The current value for selection.
+     * @returns An array of quick pick items.
+     */
+    private createConfigKeyItems(configurations: Configuration[], currentValue?: string): QuickPickItemEx<string>[] {
         return configurations.map(config => ({
             label: `${config.key === currentValue ? '$(check) ' : ''}${config.key} (${config.type || 'string'})`,
-            description: '',
             detail: `Default: ${config.default_value !== undefined ? `"${config.default_value}"` : 'Not Set'} • ${config.description || 'No description specified'}`,
             picked: currentValue === config.key,
             value: config.key
         }));
     }
 
+    /**
+     * Groups mapping options into required and optional categories.
+     * @param options The mapping options to group.
+     * @returns An object containing the grouped options.
+     */
     private groupMappingOptions(options: MappingOption[]): {
         required: MappingOption[];
         optional: MappingOption[];
@@ -749,23 +843,39 @@ export class CatalogService {
         };
     }
 
+    /**
+     * Creates quick pick items for mapping options.
+     * @param options The mapping options to create items for.
+     * @param currentValue The current value for selection.
+     * @returns An array of quick pick items.
+     */
     private createMappingQuickPickItems(
         options: MappingOption[],
         currentValue?: string
-    ): ValueQuickPickItem[] {
+    ): QuickPickItemEx<string>[] {
         return options.map(opt => ({
             label: `${opt.value === currentValue ? '$(check) ' : ''}${opt.label} (${opt.type || 'string'})`,
-            description: '',
             detail: this.formatMappingDetail(opt),
             picked: currentValue === opt.value,
             value: opt.value
         }));
     }
 
+    /**
+     * Formats the detail string for a mapping option.
+     * @param option The mapping option.
+     * @returns A formatted string.
+     */
     private formatMappingDetail(option: MappingOption): string {
         return `Default: "${option.defaultValue}" • ${option.description || 'No description specified'}`;
     }
 
+    /**
+     * Groups configuration items into required and optional categories.
+     * @param configurations The configurations to group.
+     * @param node The current catalog tree item.
+     * @returns An object containing the grouped configurations.
+     */
     private groupConfigurationItems(configurations: Configuration[], node: CatalogTreeItem): {
         required: Configuration[];
         optional: Configuration[];
@@ -784,6 +894,11 @@ export class CatalogService {
         return { required, optional };
     }
 
+    /**
+     * Retrieves the catalog ID associated with a given node.
+     * @param node The catalog tree item.
+     * @returns The catalog ID as a string, or undefined if not found.
+     */
     private async getCatalogIdForNode(node: CatalogTreeItem): Promise<string | undefined> {
         const parentNode = node.parent;
         if (parentNode && typeof parentNode.value === 'object' && parentNode.value !== null) {
@@ -795,6 +910,13 @@ export class CatalogService {
         return undefined;
     }
 
+    /**
+     * Creates a detailed description string for a flavor.
+     * @param flavorName The name of the flavor.
+     * @param details The flavor details.
+     * @param currentValue The current flavor name.
+     * @returns A formatted string.
+     */
     private createFlavorDetail(
         flavorName: string,
         details: OfferingFlavor | undefined,
@@ -819,20 +941,40 @@ export class CatalogService {
         return parts.length > 0 ? parts.join(' • ') : 'No additional details available';
     }
 
+    /**
+     * Checks if the node represents a flavor selection.
+     * @param node The catalog tree item.
+     * @returns True if it's a flavor selection, false otherwise.
+     */
     private isFlavorSelection(node: CatalogTreeItem): boolean {
         const flavorPattern = /\.dependencies\[\d+\]\.flavors\[\d+\]$/;
         return flavorPattern.test(node.jsonPath);
     }
 
+    /**
+     * Determines the type of input mapping field.
+     * @param node The catalog tree item.
+     * @returns The field type as a string.
+     */
     private getInputMappingFieldType(node: CatalogTreeItem): 'dependency_input' | 'dependency_output' | 'version_input' {
         const match = node.jsonPath.match(/\.input_mapping\[\d+\]\.([^.]+)$/);
         return (match?.[1] || 'version_input') as any;
     }
 
+    /**
+     * Handles file deletion events.
+     * @param uri The URI of the deleted file.
+     */
     public async handleFileDeletion(uri: vscode.Uri): Promise<void> {
         await this.fileSystemService.handleFileDeletion(uri);
     }
 
+    /**
+     * Updates the name of a dependency based on the offering ID.
+     * @param node The catalog tree item representing the offering ID.
+     * @param offeringId The offering ID.
+     * @param knownName An optional known name of the offering.
+     */
     private async updateDependencyName(node: CatalogTreeItem, offeringId: string, knownName?: string): Promise<void> {
         const dependencyNode = node.getDependencyParent();
         if (!dependencyNode) {

--- a/src/services/core/PromptService.ts
+++ b/src/services/core/PromptService.ts
@@ -7,43 +7,109 @@ import type {
     GroupedQuickPickOptions,
     BooleanPickOptions,
     CustomQuickPickOptions,
-    QuickPickItemEx
+    QuickPickItemEx,
+    PromptDecoratorOptions,
+    QuickInputButtons
 } from '../../types/prompt';
 
+/**
+ * Service for handling user prompts and input collection.
+ * Provides a flexible, chainable API for complex prompts while
+ * maintaining simplicity for basic use cases.
+ */
 export class PromptService {
     private static readonly logger = LoggingService.getInstance();
+    private static readonly DEFAULT_TIMEOUT = 60000; // 1 minute
 
     /**
-     * Shows an input box with validation and transformation
+     * Shows an enhanced input box with optional validation, transformation, and decorations
+     * @param options Configuration options for the input box
+     * @returns Promise resolving to the transformed input value or undefined if cancelled
      */
     public static async showInputBox<T = string>(
         options: InputBoxOptions<T>
     ): Promise<T | undefined> {
         this.logger.debug('Showing input box', { title: options.title });
 
+        const input = vscode.window.createInputBox();
+        const decorator = this.createDecorator(options.decorator);
+
         try {
-            const input = await vscode.window.showInputBox({
-                prompt: options.title,
-                placeHolder: options.placeholder,
-                value: options.initialValue,
-                password: options.password,
-                ignoreFocusOut: options.ignoreFocusOut,
-                validateInput: options.validate
+            return await new Promise<T | undefined>((resolve) => {
+                input.title = options.title;
+                input.placeholder = options.placeholder;
+                input.password = options.password ?? false;
+                input.value = options.initialValue ?? '';
+                input.buttons = [...(options.buttons ?? [])];
+
+                if (decorator) {
+                    input.validationMessage = decorator.validationMessage;
+                    void decorator.decorate(input);
+                }
+
+                // Set up validation
+                if (options.validate) {
+                    input.onDidChangeValue(async (value) => {
+                        const validation = await options.validate!(value);
+                        input.validationMessage = validation || '';
+                    });
+                }
+
+                input.onDidAccept(async () => {
+                    const value = input.value;
+                    if (options.validate) {
+                        const validation = await options.validate(value);
+                        if (validation) {
+                            input.validationMessage = validation;
+                            return;
+                        }
+                    }
+
+                    try {
+                        const result = options.transform ?
+                            await options.transform(value) :
+                            value as unknown as T;
+                        input.hide();
+                        resolve(result);
+                    } catch (error) {
+                        input.validationMessage = error instanceof Error ?
+                            error.message :
+                            'Invalid input';
+                    }
+                });
+
+                input.onDidHide(() => {
+                    input.dispose();
+                    resolve(undefined);
+                });
+
+                if (options.buttons?.length) {
+                    input.onDidTriggerButton(async (button) => {
+                        const handler = (button as QuickInputButtons).handler;
+                        if (handler) {
+                            try {
+                                const result = await handler(input.value);
+                                if (result !== undefined) {
+                                    input.value = String(result);
+                                }
+                            } catch (error) {
+                                this.logger.error('Button handler error', error);
+                            }
+                        }
+                    });
+                }
+
+                input.show();
             });
-
-            if (input === undefined) {
-                return undefined;
-            }
-
-            return options.transform ? await options.transform(input) : input as unknown as T;
-        } catch (error) {
-            this.logger.error('Error in input box', error);
-            throw error;
+        } finally {
+            input.dispose();
         }
     }
 
     /**
-     * Shows a quick pick with optional grouping
+     * Shows a quick pick with enhanced filtering and grouping capabilities
+     * @param options Configuration options for the quick pick
+     * @returns Promise resolving to the selected value(s) or undefined if cancelled
      */
     public static async showQuickPick<T>(
         options: QuickPickOptions<T>
@@ -53,73 +119,72 @@ export class PromptService {
             itemCount: options.items.length
         });
 
-        const selection = await vscode.window.showQuickPick(options.items, {
-            title: options.title,
-            placeHolder: options.placeholder,
-            matchOnDescription: options.matchOnDescription,
-            matchOnDetail: options.matchOnDetail,
-            canPickMany: options.canPickMany,
-            ignoreFocusOut: options.ignoreFocusOut
-        });
+        const quickPick = vscode.window.createQuickPick<QuickPickItemEx<T>>();
+        const decorator = this.createDecorator(options.decorator);
 
-        return selection?.value;
-    }
+        try {
+            return await new Promise<T | undefined>((resolve) => {
+                quickPick.title = options.title;
+                quickPick.placeholder = options.placeholder;
+                quickPick.items = this.prepareQuickPickItems(options.items);
+                quickPick.matchOnDescription = options.matchOnDescription ?? false;
+                quickPick.matchOnDetail = options.matchOnDetail ?? false;
+                quickPick.canSelectMany = options.canPickMany ?? false;
+                quickPick.buttons = [...(options.buttons ?? [])];
 
-    /**
-     * Shows a quick pick with items organized into groups
-     */
-    public static async showGroupedQuickPick<T>(
-        options: GroupedQuickPickOptions<T>
-    ): Promise<T | undefined> {
-        this.logger.debug('Showing grouped quick pick', {
-            title: options.title,
-            groupCount: options.groups.length
-        });
-        const allItems: Array<QuickPickItemEx<T> | vscode.QuickPickItem> = [];
+                if (decorator) {
+                    void decorator.decorate(quickPick);
+                }
 
-        // Sort groups by priority if specified
-        const sortedGroups = [...options.groups].sort((a, b) =>
-            (b.priority ?? 0) - (a.priority ?? 0)
-        );
+                if (options.activeItems?.length) {
+                    quickPick.activeItems = options.activeItems
+                        .map(item => this.findQuickPickItem(quickPick.items, item))
+                        .filter((item): item is QuickPickItemEx<T> => item !== undefined);
+                }
 
-        for (const group of sortedGroups) {
-            if (group.items.length > 0) {
-                allItems.push({
-                    label: group.label,
-                    kind: vscode.QuickPickItemKind.Separator
+                quickPick.onDidAccept(() => {
+                    const selection = quickPick.canSelectMany
+                        ? quickPick.selectedItems.map(item => item.value)
+                        : quickPick.selectedItems[0]?.value;
+                    quickPick.hide();
+                    resolve(selection as T);
                 });
-                allItems.push(...group.items);
-            }
+
+                quickPick.onDidHide(() => {
+                    resolve(undefined);
+                });
+
+                if (options.buttons?.length) {
+                    quickPick.onDidTriggerButton(async (button) => {
+                        const handler = (button as QuickInputButtons).handler;
+                        if (handler) {
+                            try {
+                                await handler(quickPick.value);
+                            } catch (error) {
+                                this.logger.error('Button handler error', error);
+                            }
+                        }
+                    });
+                }
+
+                quickPick.show();
+            });
+        } finally {
+            quickPick.dispose();
         }
-
-        const selection = await vscode.window.showQuickPick(allItems, {
-            title: options.title,
-            placeHolder: options.placeholder,
-            matchOnDescription: options.matchOnDescription,
-            matchOnDetail: options.matchOnDetail,
-            ignoreFocusOut: options.ignoreFocusOut
-        });
-
-        return (selection as QuickPickItemEx<T>)?.value;
     }
 
     /**
-     * Shows a boolean selection quick pick
+     * Shows a boolean selection with customizable labels and icons
+     * @param options Configuration options for the boolean selection
+     * @returns Promise resolving to the selected boolean value or undefined if cancelled
      */
     public static async showBooleanPick(
-        options: BooleanPickOptions & {
-            currentValue?: boolean;
-            trueLabel?: string;
-            falseLabel?: string;
-        }
+        options: BooleanPickOptions
     ): Promise<boolean | undefined> {
-        this.logger.debug('Showing boolean pick', {
-            title: options.title,
-            currentValue: options.currentValue
-        });
         const items: QuickPickItemEx<boolean>[] = [
             {
-                label: options.trueLabel ?? 'true',
+                label: options.trueLabel ?? 'True',
                 description: 'Set value to true',
                 value: true,
                 iconPath: new vscode.ThemeIcon(
@@ -127,7 +192,7 @@ export class PromptService {
                 )
             },
             {
-                label: options.falseLabel ?? 'false',
+                label: options.falseLabel ?? 'False',
                 description: 'Set value to false',
                 value: false,
                 iconPath: new vscode.ThemeIcon(
@@ -137,50 +202,301 @@ export class PromptService {
         ];
 
         return this.showQuickPick({
-            ...options,
-            items
+            title: options.title,
+            placeholder: options.placeholder,
+            items,
+            decorator: options.decorator
         });
     }
 
     /**
-     * Shows a selection with "Add Custom" option
+     * Shows a confirmation dialog with customizable buttons
+     * @param message The message to display
+     * @param options Optional configuration for the confirmation dialog
+     * @returns Promise resolving to true if confirmed, false if cancelled
      */
-    public static async showQuickPickWithCustom<T>(
-        options: QuickPickOptions<T> & {
-            customOptionLabel?: string;
-            customOptionHandler: () => Promise<T | undefined>;
+    public static async confirm(
+        message: string,
+        options: {
+            title?: string;
+            confirmLabel?: string;
+            cancelLabel?: string;
+            decorator?: PromptDecoratorOptions;
+        } = {}
+    ): Promise<boolean> {
+        return this.showQuickPick({
+            title: options.title ?? 'Confirm',
+            placeholder: message,
+            items: [
+                {
+                    label: options.confirmLabel ?? 'Yes',
+                    value: true,
+                    iconPath: new vscode.ThemeIcon('check')
+                },
+                {
+                    label: options.cancelLabel ?? 'No',
+                    value: false,
+                    iconPath: new vscode.ThemeIcon('x')
+                }
+            ],
+            decorator: options.decorator
+        }).then(result => result ?? false);
+    }
+
+    /**
+     * Creates a custom decorator for input controls
+     */
+    private static createDecorator(options?: PromptDecoratorOptions) {
+        if (!options) { return undefined; }
+
+        return {
+            validationMessage: options.validationMessage,
+            decorate: async (input: vscode.QuickInput) => {
+                if (options.busy) {
+                    input.busy = true;
+                }
+                if (options.enabled === false) {
+                    input.enabled = false;
+                }
+                if (options.timeout) {
+                    setTimeout(() => {
+                        input.hide();
+                    }, options.timeout);
+                }
+            }
+        };
+    }
+
+    
+
+    /**
+     * Prepares items for the quick pick by adding icons and formatting
+     */
+    private static prepareQuickPickItems<T>(
+        items: Array<QuickPickItemEx<T>>
+    ): Array<QuickPickItemEx<T>> {
+        return items.map(item => ({
+            ...item,
+            iconPath: item.iconPath ?? this.getDefaultIcon(item)
+        }));
+    }
+
+    /**
+     * Gets a default icon for a quick pick item based on its type
+     */
+    private static getDefaultIcon(item: QuickPickItemEx<unknown>): vscode.ThemeIcon | undefined {
+        if (item.kind === vscode.QuickPickItemKind.Separator) {
+            return undefined;
         }
+        if (typeof item.value === 'boolean') {
+            return new vscode.ThemeIcon(item.value ? 'check' : 'x');
+        }
+        return undefined;
+    }
+
+    /**
+ * Shows a quick pick with an additional custom input option.
+ * Combines quick pick selection with custom input capability.
+ * 
+ * @param options Configuration options including custom input handling
+ * @returns Promise resolving to selected value or custom input, undefined if cancelled
+ */
+    public static async showQuickPickWithCustom<T>(
+        options: CustomQuickPickOptions<T>
     ): Promise<T | undefined> {
         this.logger.debug('Showing quick pick with custom option', {
             title: options.title,
             itemCount: options.items.length
         });
-        const customOption: QuickPickItemEx<string> = {
-            label: options.customOptionLabel ?? '$(edit) Enter Custom Value',
-            description: 'Manually enter a value',
-            value: '__custom__',
-            iconPath: new vscode.ThemeIcon('edit'),
-            alwaysShow: true
-        };
 
-        const allItems = [
-            customOption,
-            { label: 'Available Options', kind: vscode.QuickPickItemKind.Separator },
-            ...options.items
-        ];
+        const quickPick = vscode.window.createQuickPick<QuickPickItemEx<T>>();
+        try {
+            // Create combined items with custom option first
+            const customItem: QuickPickItemEx<string> = {
+                label: options.customOptionLabel ?? '$(edit) Enter Custom Value',
+                description: 'Manually enter a value',
+                value: '__custom__' as any,
+                alwaysShow: true
+            };
 
-        const selection = await vscode.window.showQuickPick(allItems, {
+            // Set up quick pick
+            quickPick.title = options.title;
+            quickPick.placeholder = options.placeholder;
+            quickPick.items = [customItem as QuickPickItemEx<T>, ...options.items];
+            quickPick.matchOnDescription = options.matchOnDescription ?? false;
+            quickPick.matchOnDetail = options.matchOnDetail ?? false;
+
+            // Apply decorator if provided
+            if (options.decorator) {
+                quickPick.busy = options.decorator.busy ?? false;
+                if (options.decorator.enabled !== undefined) {
+                    quickPick.enabled = options.decorator.enabled;
+                }
+                if (options.decorator.validationMessage) {
+                    // Create a description detail for the validation message
+                    quickPick.buttons = [
+                        {
+                            iconPath: new vscode.ThemeIcon('info'),
+                            tooltip: options.decorator.validationMessage
+                        }
+                    ];
+                }
+            }
+
+            return await new Promise<T | undefined>((resolve) => {
+                quickPick.onDidAccept(async () => {
+                    const selection = quickPick.selectedItems[0];
+                    if (!selection) {
+                        resolve(undefined);
+                        return;
+                    }
+
+                    if (selection.value === '__custom__') {
+                        quickPick.hide();
+                        const customValue = await options.customOptionHandler();
+                        resolve(customValue);
+                    } else {
+                        resolve(selection.value);
+                    }
+                    quickPick.hide();
+                });
+
+                quickPick.onDidHide(() => {
+                    quickPick.dispose();
+                    resolve(undefined);
+                });
+
+                quickPick.show();
+            });
+        } finally {
+            quickPick.dispose();
+        }
+    }
+
+    /**
+ * Shows a quick pick with items organized into logical groups.
+ * Groups can be prioritized and items within groups maintain their original order.
+ * 
+ * @param options Configuration options including group definitions
+ * @returns Promise resolving to the selected value or undefined if cancelled
+ */
+    public static async showGroupedQuickPick<T>(
+        options: GroupedQuickPickOptions<T>
+    ): Promise<T | undefined> {
+        this.logger.debug('Showing grouped quick pick', {
             title: options.title,
-            placeHolder: options.placeholder,
-            matchOnDescription: options.matchOnDescription,
-            matchOnDetail: options.matchOnDetail,
-            ignoreFocusOut: options.ignoreFocusOut
+            groupCount: options.groups.length,
+            totalItems: options.groups.reduce((sum, g) => sum + g.items.length, 0)
         });
 
-        if ((selection as QuickPickItemEx<string>)?.value === '__custom__') {
-            return options.customOptionHandler();
-        }
+        const quickPick = vscode.window.createQuickPick<QuickPickItemEx<T>>();
 
-        return (selection as QuickPickItemEx<T>)?.value;
+        try {
+            // Sort groups by priority (higher priority first) and create flat item list
+            const sortedGroups = [...options.groups].sort((a, b) =>
+                (b.priority ?? 0) - (a.priority ?? 0)
+            );
+
+            const allItems: Array<QuickPickItemEx<T>> = [];
+
+            // Build items list with separators
+            for (const group of sortedGroups) {
+                if (group.items.length > 0) {
+                    // Add group separator
+                    allItems.push({
+                        label: group.label,
+                        kind: vscode.QuickPickItemKind.Separator,
+                        value: undefined as any // Separators won't be selectable
+                    });
+
+                    // Add group items
+                    allItems.push(...group.items);
+                }
+            }
+
+            // Configure quick pick
+            quickPick.title = options.title;
+            quickPick.placeholder = options.placeholder;
+            quickPick.items = allItems;
+            quickPick.matchOnDescription = options.matchOnDescription ?? false;
+            quickPick.matchOnDetail = options.matchOnDetail ?? false;
+            quickPick.canSelectMany = options.canPickMany ?? false;
+
+            // Set active items if specified
+            if (options.activeItems?.length) {
+                quickPick.activeItems = options.activeItems
+                    .map(item => this.findQuickPickItem(allItems, item))
+                    .filter((item): item is QuickPickItemEx<T> =>
+                        item !== undefined && item.kind !== vscode.QuickPickItemKind.Separator
+                    );
+            }
+
+            // Apply decorator if provided
+            if (options.decorator) {
+                quickPick.busy = options.decorator.busy ?? false;
+                if (options.decorator.enabled !== undefined) {
+                    quickPick.enabled = options.decorator.enabled;
+                }
+            }
+
+            // Add buttons if provided
+            if (options.buttons?.length) {
+                quickPick.buttons = options.buttons;
+
+                quickPick.onDidTriggerButton(async (button) => {
+                    const handler = (button as QuickInputButtons).handler;
+                    if (handler) {
+                        try {
+                            // Pass current value to handler
+                            const result = await handler(quickPick.value);
+                            if (result) {
+                                quickPick.value = result;
+                            }
+                        } catch (error) {
+                            this.logger.error('Button handler error', error);
+                        }
+                    }
+                });
+            }
+
+            return await new Promise<T | undefined>((resolve) => {
+                quickPick.onDidAccept(() => {
+                    const selection = options.canPickMany
+                        ? quickPick.selectedItems
+                            .filter(item => item.kind !== vscode.QuickPickItemKind.Separator)
+                            .map(item => item.value)
+                        : quickPick.selectedItems[0]?.value;
+
+                    quickPick.hide();
+                    resolve(selection as T);
+                });
+
+                quickPick.onDidHide(() => {
+                    quickPick.dispose();
+                    resolve(undefined);
+                });
+
+                quickPick.show();
+            });
+        } finally {
+            quickPick.dispose();
+        }
+    }
+
+    /**
+     * Helper method to find a quick pick item by its value
+     * 
+     * @param items Array of quick pick items to search
+     * @param value The value to find
+     * @returns Matching quick pick item or undefined
+     */
+    private static findQuickPickItem<T>(
+        items: ReadonlyArray<QuickPickItemEx<T>>,
+        value: T
+    ): QuickPickItemEx<T> | undefined {
+        return items.find(item =>
+            item.kind !== vscode.QuickPickItemKind.Separator &&
+            item.value === value
+        );
     }
 }

--- a/src/types/prompt/index.ts
+++ b/src/types/prompt/index.ts
@@ -1,46 +1,121 @@
 // src/types/prompt/index.ts
 import type * as vscode from 'vscode';
-import type { ValueQuickPickItem } from '../common';
 
-export interface BasePromptOptions {
-    title: string;
-    placeholder?: string;
-    ignoreFocusOut?: boolean;
+/**
+ * Options for decorating input controls with visual enhancements
+ */
+export interface PromptDecoratorOptions {
+    /** Loading indicator state */
+    busy?: boolean;
+    /** Enabled/disabled state */
+    enabled?: boolean;
+    /** Custom validation message */
+    validationMessage?: string;
+    /** Timeout in milliseconds */
+    timeout?: number;
 }
 
+/**
+ * Extended button type with handler function
+ */
+export interface QuickInputButtons extends vscode.QuickInputButton {
+    handler?: (value: string) => Promise<string | undefined>;
+}
+
+/**
+ * Base options for all prompt types
+ */
+export interface BasePromptOptions {
+    /** Title displayed at the top of the prompt */
+    title: string;
+    /** Placeholder text when no value is entered */
+    placeholder?: string;
+    /** Visual decorations and enhancements */
+    decorator?: PromptDecoratorOptions;
+    /** Custom buttons with handlers */
+    buttons?: QuickInputButtons[];
+}
+
+/**
+ * Options for input box prompts
+ */
 export interface InputBoxOptions<T> extends BasePromptOptions {
+    /** Initial value to display */
     initialValue?: string;
+    /** Whether to mask the input (for passwords) */
     password?: boolean;
+    /** Validation function */
     validate?: (value: string) => string | null | Promise<string | null>;
+    /** Transform function to convert string input to final type */
     transform?: (value: string) => T | Promise<T>;
 }
 
-export interface QuickPickItemEx<T> extends ValueQuickPickItem<T> {
-    iconPath?: vscode.ThemeIcon;
+/**
+ * Extended QuickPickItem with value and icon support
+ */
+export interface QuickPickItemEx<T> extends vscode.QuickPickItem {
+    /** The value associated with this item */
+    value: T;
+    /** Optional icon to display */
+    iconPath?: vscode.ThemeIcon | vscode.Uri;
+    /** Whether to always show this item regardless of filter */
+    alwaysShow?: boolean;
 }
 
+/**
+ * Options for quick pick prompts
+ */
 export interface QuickPickOptions<T> extends BasePromptOptions {
-    items: QuickPickItemEx<T>[];
+    /** Available items to pick from */
+    items: Array<QuickPickItemEx<T>>;
+    /** Whether to match on description text */
     matchOnDescription?: boolean;
+    /** Whether to match on detail text */
     matchOnDetail?: boolean;
+    /** Allow selecting multiple items */
     canPickMany?: boolean;
+    /** Initially active items */
+    activeItems?: T[];
 }
 
-export interface GroupedQuickPickOptions<T> extends QuickPickOptions<T> {
-    groups: {
-        label: string;
-        items: QuickPickItemEx<T>[];
-        priority?: number;
-    }[];
+/**
+ * Group definition for grouped quick picks
+ */
+export interface QuickPickGroup<T> {
+    /** Group label displayed as separator */
+    label: string;
+    /** Items in this group */
+    items: Array<QuickPickItemEx<T>>;
+    /** Optional sort priority (higher numbers first) */
+    priority?: number;
 }
 
+/**
+ * Options for grouped quick pick prompts
+ */
+export interface GroupedQuickPickOptions<T> extends Omit<QuickPickOptions<T>, 'items'> {
+    /** Groups of items */
+    groups: Array<QuickPickGroup<T>>;
+}
+
+/**
+ * Options for boolean selection prompts
+ */
 export interface BooleanPickOptions extends BasePromptOptions {
+    /** Current boolean value */
     currentValue?: boolean;
+    /** Label for true option */
     trueLabel?: string;
+    /** Label for false option */
     falseLabel?: string;
 }
 
+/**
+ * Options for quick picks with custom input option
+ */
 export interface CustomQuickPickOptions<T> extends QuickPickOptions<T> {
+    /** Label for custom input option */
     customOptionLabel?: string;
+    /** Handler for custom input */
     customOptionHandler: () => Promise<T | undefined>;
 }


### PR DESCRIPTION
Refactor the prompt service to improve structure and introduce support for arbitrary value types in input mapping prompts. This enhances flexibility and usability in handling various input scenarios.

- [x] https://github.com/daniel-butler-irl/VS_Code_Catalog_Json_Editor/issues/36
- [x] https://github.com/daniel-butler-irl/VS_Code_Catalog_Json_Editor/issues/22