### PR TITLE
Refactor tooltip creation and add color settings for IDs in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,6 +194,42 @@
           "light": "#B50000",
           "highContrast": "#FF0000"
         }
+      },
+      {
+        "id": "ibmCatalog.catalogIdColor",
+        "description": "Color for catalog id",
+        "defaults": {
+          "dark": "#007ACC",
+          "light": "#007ACC",
+          "highContrast": "#007ACC"
+        }
+      },
+      {
+        "id": "ibmCatalog.offeringIdColor",
+        "description": "Color for offering id",
+        "defaults": {
+          "dark": "#007ACC",
+          "light": "#007ACC",
+          "highContrast": "#007ACC"
+        }
+      },
+      {
+        "id": "ibmCatalog.flavorColor",
+        "description": "Color for flavor",
+        "defaults": {
+          "dark": "#007ACC",
+          "light": "#007ACC",
+          "highContrast": "#007ACC"
+        }
+      },
+      {
+        "id": "ibmCatalog.versionColor",
+        "description": "Color for version",
+        "defaults": {
+          "dark": "#007ACC",
+          "light": "#007ACC",
+          "highContrast": "#007ACC"
+        }
       }
     ],
     "keybindings": [


### PR DESCRIPTION
Simplify tooltip generation for catalog items and introduce color settings for catalog, offering, flavor, and version IDs in package.json.

https://github.com/daniel-butler-irl/VS_Code_Catalog_Json_Editor/issues/47
https://github.com/daniel-butler-irl/VS_Code_Catalog_Json_Editor/issues/46
https://github.com/daniel-butler-irl/VS_Code_Catalog_Json_Editor/issues/48