### PR TITLE
Enhance input mapping flow with version_input option and version bump to 0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ibm-catalog-json-editor",
   "displayName": "IBM Catalog JSON Editor",
   "description": "VS Code extension for managing IBM Cloud catalog JSON files",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publisher": "DanielButler",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Introduce a new mapping type, `version_input`, to the input mapping flow, allowing users to select it as an option. Update the version to 0.2.3.

https://github.com/daniel-butler-irl/VS_Code_Catalog_Json_Editor/issues/63