### PR TITLE
Add configuration handling and field editing capabilities in CatalogService

### DIFF
--- a/src/models/CatalogTreeItem.ts
+++ b/src/models/CatalogTreeItem.ts
@@ -691,7 +691,8 @@ export class CatalogTreeItem extends vscode.TreeItem {
             this.label === 'catalog_id' ||
             this.isOfferingIdInDependency() ||
             this.isDependencyFlavor() ||
-            this.isInputMappingField();
+            this.isInputMappingField() ||
+            (this.label === 'configuration' && Array.isArray(this.value));
     }
 
     /**

--- a/src/types/catalog/index.ts
+++ b/src/types/catalog/index.ts
@@ -176,3 +176,30 @@ export enum CatalogServiceMode {
     /** Full functionality with workspace and catalog file */
     Full = 'full'
 }
+
+
+/**
+ * 
+ */
+export interface ConfigurationFieldSelection {
+    key: string;
+    included: boolean;
+    required: boolean;
+    description?: string;
+    type?: string;
+    default_value?: any;
+  }
+
+  export type ConfigurationFieldProperty = keyof Omit<Configuration, 'key'>;
+
+
+  export interface Configuration {
+    key: string;
+    type?: any;
+    default_value?: any;
+    description?: string;
+    required?: boolean;
+    custom_config?: any;
+    display_name?: string;
+  }
+  


### PR DESCRIPTION
- [x] https://github.com/daniel-butler-irl/VS_Code_Catalog_Json_Editor/issues/66

Introduce functionality for editing configuration fields within the CatalogService, allowing users to manage configuration arrays and their properties more effectively. This includes enhancements to the quick pick interface for selecting multiple properties to delete.
