### PR TITLE
feat: Add ignore_auto_referencing support for dependency input mappings

### DIFF
--- a/src/types/catalog/index.ts
+++ b/src/types/catalog/index.ts
@@ -69,6 +69,11 @@ export interface Dependency {
      * Input mappings for this dependency
      */
     input_mapping: InputMapping[];
+
+    /**
+     * List of inputs that should not be auto-referenced
+     */
+    ignore_auto_referencing?: string[];
 }
 
 /**
@@ -188,12 +193,12 @@ export interface ConfigurationFieldSelection {
     description?: string;
     type?: string;
     default_value?: any;
-  }
+}
 
-  export type ConfigurationFieldProperty = keyof Omit<Configuration, 'key'>;
+export type ConfigurationFieldProperty = keyof Omit<Configuration, 'key'>;
 
 
-  export interface Configuration {
+export interface Configuration {
     key: string;
     type?: any;
     default_value?: any;
@@ -201,5 +206,4 @@ export interface ConfigurationFieldSelection {
     required?: boolean;
     custom_config?: any;
     display_name?: string;
-  }
-  
+}


### PR DESCRIPTION
- Introduce new `ignore_auto_referencing` field in Dependency interface
- Implement UI for managing inputs to ignore auto-referencing
- Add prompts for selecting and updating ignore_auto_referencing list
- Enable reference direction selection for input mappings
- Add handling for missing reference_version in input mappings