### PR TITLE
fix: reference direction selection in mapping configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ibm-catalog-json-editor",
   "displayName": "IBM Catalog JSON Editor",
   "description": "VS Code extension for managing IBM Cloud catalog JSON files",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "publisher": "DanielButler",
   "repository": {
     "type": "git",


### PR DESCRIPTION
https://github.com/daniel-butler-irl/VS_Code_Catalog_Json_Editor/issues/92

- Enhance reference direction selection with a more detailed QuickPick UI
- Add descriptive options for mapping direction between dependencies
- Improve validation and error handling for reference version configuration
- Bump version to 0.3.3