### PR TITLE
Add Collapse All functionality to IBM Catalog Tree View

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,12 @@
         "icon": "$(trash)"
       },
       {
+        "command": "ibmCatalog.collapseAll",
+        "title": "Collapse All",
+        "category": "IBM Catalog",
+        "icon": "$(collapse-all)"
+      },
+      {
         "command": "ibmCatalog.showLogs",
         "title": "Show IBM Catalog Logs",
         "category": "IBM Catalog"
@@ -115,6 +121,11 @@
       "view/title": [
         {
           "command": "ibmCatalog.clearCache",
+          "when": "view == ibmCatalogTree",
+          "group": "navigation"
+        },
+        {
+          "command": "ibmCatalog.collapseAll",
           "when": "view == ibmCatalogTree",
           "group": "navigation"
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -217,6 +217,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                 treeProvider.refresh();
                 vscode.window.showInformationMessage('IBM Catalog cache cleared');
             }),
+            vscode.commands.registerCommand('ibmCatalog.collapseAll', async () => {
+                // Ensure tree view has focus
+                await treeView.reveal(treeView.selection[0], { focus: true });
+
+                // Collapse all nodes
+                treeProvider.collapseAll();
+            }),
             vscode.commands.registerCommand('ibmCatalog.editElement', async (node: CatalogTreeItem) => {
                 const catalogFilePath = catalogService.getCatalogFilePath();
                 if (catalogFilePath) {


### PR DESCRIPTION
Implement a 'Collapse All' command for the IBM Catalog tree view, allowing users to collapse all nodes efficiently. Ensure the expanded state is restored when the tree view becomes visible.

https://github.com/daniel-butler-irl/VS_Code_Catalog_Json_Editor/issues/97